### PR TITLE
Enhance blog interactivity with modern HTML features

### DIFF
--- a/build.py
+++ b/build.py
@@ -493,7 +493,7 @@ def render_index(posts: Iterable[Post]) -> str:
         summary_html = summary if summary else ""
         card_html = f"""
     <article class=\"post-card\">
-      <template shadowroot=\"open\">
+      <template shadowrootmode=\"open\">
         <style>
           :host {{
             display: block;

--- a/docs/great-weekend-in-almaty.html
+++ b/docs/great-weekend-in-almaty.html
@@ -4,7 +4,7 @@
 <title>Great Weekend in Almaty – Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="post">
 <header>
   <p><a href="index.html">Wanderlust &amp; Wonder</a></p>
   <p>Tiny stories from the road</p>
@@ -12,7 +12,7 @@
 <main>
   <article>
     <h1>Great Weekend in Almaty</h1>
-    <p class="post-date">January 15, 2024</p>
+    <p class="post-date"><time datetime="2024-01-15">January 15, 2024</time></p>
     <p>Almaty never fails to surprise me. This weekend was particularly magical - the kind that makes you fall in love with a city all over again.</p>
 <p>Started Saturday morning with a walk through Panfilov Park. The autumn leaves were at their peak, creating this golden carpet that crunched underfoot. Found a small café tucked away behind the opera house where they serve the most incredible samsa - flaky, buttery, and filled with perfectly spiced lamb.</p>
 <p>The highlight was stumbling upon a local art market near Zhibek Zholy. Met this incredible painter who works exclusively with natural pigments from the mountains. His landscapes of the Tian Shan range were breathtaking - you could almost feel the crisp mountain air.</p>
@@ -24,5 +24,34 @@
 <footer>
   <p><a href="index.html">Back to all stories</a></p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/how-this-blog-works.html
+++ b/docs/how-this-blog-works.html
@@ -4,7 +4,7 @@
 <title>How This Blog Works – Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="post">
 <header>
   <p><a href="index.html">Wanderlust &amp; Wonder</a></p>
   <p>Tiny stories from the road</p>
@@ -12,9 +12,9 @@
 <main>
   <article>
     <h1>How This Blog Works</h1>
-    <p class="post-date">January 30, 2024</p>
-    <p>This site is deliberately tiny. Every story lives as a text file inside the <code>posts/</code> folder, and <code>python3 build.py</code> glues them together into one HTML page at <code>docs/index.html</code>.</p>
-<p>To add something new, drop another text file in <code>posts/</code> using the pattern <code>YYYY-MM-DD-short-title.txt</code>. Keep the title on the first line, leave a blank line, and then write the story in plain paragraphs or bullets that start with <code>- </code>. Run <code>python3 build.py</code> to rebuild the page.</p>
+    <p class="post-date"><time datetime="2024-01-30">January 30, 2024</time></p>
+    <p>This site is deliberately tiny—a <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-1">static site</button><aside id="glossary-popover-1" class="glossary-popover" popover="auto" role="note"><strong>static site</strong><span class="glossary-definition">A collection of pages that are prebuilt ahead of time and can be served as-is from any web host.</span></aside></span> Every story lives as a text file inside the <code>posts/</code> folder, and <code>python3 build.py</code> glues them together into one HTML page at <code>docs/index.html</code>.</p>
+<p>To add something new, drop another text file in <code>posts/</code> using the pattern <code>YYYY-MM-DD-short-title.txt</code>. Keep the title on the first line, leave a blank line, and then write the story in plain paragraphs or bullets that start with <code>- </code>. Run <code>python3 build.py</code> to rebuild the page with a fresh <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-2">build step</button><aside id="glossary-popover-2" class="glossary-popover" popover="auto" role="note"><strong>build step</strong><span class="glossary-definition">A single command that regenerates every page from the source files so nothing can fall out of sync.</span></aside></span>.</p>
 <p>Need to remove a story? Delete its text file and rebuild. The single page is recreated from scratch each time, so it will only show the files that still exist.</p>
 <p>No templates, no feeds, and no extra assets—just text files in, one page out.</p>
   </article>
@@ -22,5 +22,34 @@
 <footer>
   <p><a href="index.html">Back to all stories</a></p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,40 +4,299 @@
 <title>Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="home">
 <header>
   <h1>Wanderlust &amp; Wonder</h1>
   <p>Tiny stories from the road</p>
 </header>
-<main>
-<article>
-      <h2><a href="ios-deep-links-for-vless.html">Understanding iOS Deep Links for VLESS Imports</a></h2>
-      <p class="post-date">February 28, 2024</p>
+<main class="feed">
+<article class="post-card">
+      <template shadowroot="open">
+        <style>
+          :host {
+            display: block;
+          }
+          .card {
+            display: grid;
+            gap: 0.75rem;
+          }
+          header {
+            margin: 0;
+          }
+          .meta {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          .summary {
+            display: grid;
+            gap: 0.65rem;
+          }
+          ::slotted(h2) {
+            margin: 0;
+            font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+          }
+          ::slotted(.post-date) {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          ::slotted(p) {
+            margin: 0;
+          }
+        </style>
+        <article class="card" part="surface">
+          <header part="header">
+            <slot name="title"></slot>
+          </header>
+          <div class="meta" part="meta">
+            <slot name="date"></slot>
+          </div>
+          <div class="summary" part="summary">
+            <slot></slot>
+          </div>
+        </article>
+      </template>
+      <h2 slot="title"><a href="ios-deep-links-for-vless.html">Understanding iOS Deep Links for VLESS Imports</a></h2>
+      <p slot="date" class="post-date"><time datetime="2024-02-28">February 28, 2024</time></p>
       <p>Deep links let iOS hand off URLs directly to apps that have registered specific schemes. When the user taps a link with the <code>streisand://</code> or <code>v2box://</code> scheme, the operating system looks for a matching app identifier and, if present, launches the app while passing everything after the scheme as parameters.</p>
     </article>
-<article>
-      <h2><a href="how-this-blog-works.html">How This Blog Works</a></h2>
-      <p class="post-date">January 30, 2024</p>
-      <p>This site is deliberately tiny. Every story lives as a text file inside the <code>posts/</code> folder, and <code>python3 build.py</code> glues them together into one HTML page at <code>docs/index.html</code>.</p>
+<article class="post-card">
+      <template shadowroot="open">
+        <style>
+          :host {
+            display: block;
+          }
+          .card {
+            display: grid;
+            gap: 0.75rem;
+          }
+          header {
+            margin: 0;
+          }
+          .meta {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          .summary {
+            display: grid;
+            gap: 0.65rem;
+          }
+          ::slotted(h2) {
+            margin: 0;
+            font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+          }
+          ::slotted(.post-date) {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          ::slotted(p) {
+            margin: 0;
+          }
+        </style>
+        <article class="card" part="surface">
+          <header part="header">
+            <slot name="title"></slot>
+          </header>
+          <div class="meta" part="meta">
+            <slot name="date"></slot>
+          </div>
+          <div class="summary" part="summary">
+            <slot></slot>
+          </div>
+        </article>
+      </template>
+      <h2 slot="title"><a href="how-this-blog-works.html">How This Blog Works</a></h2>
+      <p slot="date" class="post-date"><time datetime="2024-01-30">January 30, 2024</time></p>
+      <p>This site is deliberately tiny—a <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-1">static site</button><aside id="glossary-popover-1" class="glossary-popover" popover="auto" role="note"><strong>static site</strong><span class="glossary-definition">A collection of pages that are prebuilt ahead of time and can be served as-is from any web host.</span></aside></span> Every story lives as a text file inside the <code>posts/</code> folder, and <code>python3 build.py</code> glues them together into one HTML page at <code>docs/index.html</code>.</p>
     </article>
-<article>
-      <h2><a href="researching-el-norte-de-espana.html">Researching El Norte de España</a></h2>
-      <p class="post-date">January 25, 2024</p>
+<article class="post-card">
+      <template shadowroot="open">
+        <style>
+          :host {
+            display: block;
+          }
+          .card {
+            display: grid;
+            gap: 0.75rem;
+          }
+          header {
+            margin: 0;
+          }
+          .meta {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          .summary {
+            display: grid;
+            gap: 0.65rem;
+          }
+          ::slotted(h2) {
+            margin: 0;
+            font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+          }
+          ::slotted(.post-date) {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          ::slotted(p) {
+            margin: 0;
+          }
+        </style>
+        <article class="card" part="surface">
+          <header part="header">
+            <slot name="title"></slot>
+          </header>
+          <div class="meta" part="meta">
+            <slot name="date"></slot>
+          </div>
+          <div class="summary" part="summary">
+            <slot></slot>
+          </div>
+        </article>
+      </template>
+      <h2 slot="title"><a href="researching-el-norte-de-espana.html">Researching El Norte de España</a></h2>
+      <p slot="date" class="post-date"><time datetime="2024-01-25">January 25, 2024</time></p>
       <p>There&#x27;s something about northern Spain that calls to me. Maybe it&#x27;s the rugged coastline, the ancient Celtic heritage, or the way the mountains meet the sea. I&#x27;ve been researching the region for months now, and each discovery makes me more eager to visit.</p>
     </article>
-<article>
-      <h2><a href="interesting-meeting-in-cement-museum.html">Interesting Meeting in the Cement Museum</a></h2>
-      <p class="post-date">January 20, 2024</p>
+<article class="post-card">
+      <template shadowroot="open">
+        <style>
+          :host {
+            display: block;
+          }
+          .card {
+            display: grid;
+            gap: 0.75rem;
+          }
+          header {
+            margin: 0;
+          }
+          .meta {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          .summary {
+            display: grid;
+            gap: 0.65rem;
+          }
+          ::slotted(h2) {
+            margin: 0;
+            font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+          }
+          ::slotted(.post-date) {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          ::slotted(p) {
+            margin: 0;
+          }
+        </style>
+        <article class="card" part="surface">
+          <header part="header">
+            <slot name="title"></slot>
+          </header>
+          <div class="meta" part="meta">
+            <slot name="date"></slot>
+          </div>
+          <div class="summary" part="summary">
+            <slot></slot>
+          </div>
+        </article>
+      </template>
+      <h2 slot="title"><a href="interesting-meeting-in-cement-museum.html">Interesting Meeting in the Cement Museum</a></h2>
+      <p slot="date" class="post-date"><time datetime="2024-01-20">January 20, 2024</time></p>
       <p>You know those places that sound completely random but turn out to be unexpectedly fascinating? The Cement Museum in Novorossiysk is exactly that.</p>
     </article>
-<article>
-      <h2><a href="great-weekend-in-almaty.html">Great Weekend in Almaty</a></h2>
-      <p class="post-date">January 15, 2024</p>
+<article class="post-card">
+      <template shadowroot="open">
+        <style>
+          :host {
+            display: block;
+          }
+          .card {
+            display: grid;
+            gap: 0.75rem;
+          }
+          header {
+            margin: 0;
+          }
+          .meta {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          .summary {
+            display: grid;
+            gap: 0.65rem;
+          }
+          ::slotted(h2) {
+            margin: 0;
+            font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+          }
+          ::slotted(.post-date) {
+            margin: 0;
+            font-size: 0.9rem;
+            color: color-mix(in srgb, currentColor 55%, transparent);
+          }
+          ::slotted(p) {
+            margin: 0;
+          }
+        </style>
+        <article class="card" part="surface">
+          <header part="header">
+            <slot name="title"></slot>
+          </header>
+          <div class="meta" part="meta">
+            <slot name="date"></slot>
+          </div>
+          <div class="summary" part="summary">
+            <slot></slot>
+          </div>
+        </article>
+      </template>
+      <h2 slot="title"><a href="great-weekend-in-almaty.html">Great Weekend in Almaty</a></h2>
+      <p slot="date" class="post-date"><time datetime="2024-01-15">January 15, 2024</time></p>
       <p>Almaty never fails to surprise me. This weekend was particularly magical - the kind that makes you fall in love with a city all over again.</p>
     </article>
 </main>
 <footer>
   <p>Built with plain text files and a small Python script.</p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 </header>
 <main class="feed">
 <article class="post-card">
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           :host {
             display: block;
@@ -62,7 +62,7 @@
       <p>Deep links let iOS hand off URLs directly to apps that have registered specific schemes. When the user taps a link with the <code>streisand://</code> or <code>v2box://</code> scheme, the operating system looks for a matching app identifier and, if present, launches the app while passing everything after the scheme as parameters.</p>
     </article>
 <article class="post-card">
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           :host {
             display: block;
@@ -113,7 +113,7 @@
       <p>This site is deliberately tiny—a <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-1">static site</button><aside id="glossary-popover-1" class="glossary-popover" popover="auto" role="note"><strong>static site</strong><span class="glossary-definition">A collection of pages that are prebuilt ahead of time and can be served as-is from any web host.</span></aside></span> Every story lives as a text file inside the <code>posts/</code> folder, and <code>python3 build.py</code> glues them together into one HTML page at <code>docs/index.html</code>.</p>
     </article>
 <article class="post-card">
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           :host {
             display: block;
@@ -164,7 +164,7 @@
       <p>There&#x27;s something about northern Spain that calls to me. Maybe it&#x27;s the rugged coastline, the ancient Celtic heritage, or the way the mountains meet the sea. I&#x27;ve been researching the region for months now, and each discovery makes me more eager to visit.</p>
     </article>
 <article class="post-card">
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           :host {
             display: block;
@@ -215,7 +215,7 @@
       <p>You know those places that sound completely random but turn out to be unexpectedly fascinating? The Cement Museum in Novorossiysk is exactly that.</p>
     </article>
 <article class="post-card">
-      <template shadowroot="open">
+      <template shadowrootmode="open">
         <style>
           :host {
             display: block;

--- a/docs/interesting-meeting-in-cement-museum.html
+++ b/docs/interesting-meeting-in-cement-museum.html
@@ -4,7 +4,7 @@
 <title>Interesting Meeting in the Cement Museum – Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="post">
 <header>
   <p><a href="index.html">Wanderlust &amp; Wonder</a></p>
   <p>Tiny stories from the road</p>
@@ -12,7 +12,7 @@
 <main>
   <article>
     <h1>Interesting Meeting in the Cement Museum</h1>
-    <p class="post-date">January 20, 2024</p>
+    <p class="post-date"><time datetime="2024-01-20">January 20, 2024</time></p>
     <p>You know those places that sound completely random but turn out to be unexpectedly fascinating? The Cement Museum in Novorossiysk is exactly that.</p>
 <p>Went there with friends on a whim - we were driving along the Black Sea coast and saw the sign. &quot;Cement Museum? Why not?&quot; we thought. Three hours later, we were still there, completely absorbed.</p>
 <p>The museum is housed in what used to be an actual cement factory. The industrial architecture alone is worth the visit - these massive concrete structures that somehow feel both imposing and beautiful. The guide, a retired engineer named Dmitri, had worked there for 40 years and his passion was infectious.</p>
@@ -25,5 +25,34 @@
 <footer>
   <p><a href="index.html">Back to all stories</a></p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "great-weekend-in-almaty.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "great-weekend-in-almaty.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/ios-deep-links-for-vless.html
+++ b/docs/ios-deep-links-for-vless.html
@@ -4,7 +4,7 @@
 <title>Understanding iOS Deep Links for VLESS Imports – Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="post">
 <header>
   <p><a href="index.html">Wanderlust &amp; Wonder</a></p>
   <p>Tiny stories from the road</p>
@@ -12,7 +12,7 @@
 <main>
   <article>
     <h1>Understanding iOS Deep Links for VLESS Imports</h1>
-    <p class="post-date">February 28, 2024</p>
+    <p class="post-date"><time datetime="2024-02-28">February 28, 2024</time></p>
     <p>Deep links let iOS hand off URLs directly to apps that have registered specific schemes. When the user taps a link with the <code>streisand://</code> or <code>v2box://</code> scheme, the operating system looks for a matching app identifier and, if present, launches the app while passing everything after the scheme as parameters.</p>
 <p>Both Streisand and V2box register custom URL schemes to streamline importing proxy configurations. The apps expect a JSON or base64 payload that matches the VLESS format, so it is common to wrap the configuration in a single URL-encoded parameter. Below are two example deep links that target each app and deliver the same VLESS configuration:</p>
 <ol><li>Streisand deep link: <a href="streisand://import?config=%7B%22v%22%3A%222%22%2C%22ps%22%3A%22Example%20VLESS%22%2C%22add%22%3A%22example.com%22%2C%22port%22%3A443%2C%22id%22%3A%22d3d94468-2e02-4a02-b1f5-8da3eb3b0123%22%2C%22aid%22%3A0%2C%22scy%22%3A%22auto%22%2C%22net%22%3A%22ws%22%2C%22type%22%3A%22none%22%2C%22host%22%3A%22cdn.example.com%22%2C%22path%22%3A%22%2Fvless%22%2C%22tls%22%3A%22tls%22%7D">streisand://import?config=%7B%22v%22%3A%222%22%2C%22ps%22%3A%22Example%20VLESS%22%2C%22add%22%3A%22example.com%22%2C%22port%22%3A443%2C%22id%22%3A%22d3d94468-2e02-4a02-b1f5-8da3eb3b0123%22%2C%22aid%22%3A0%2C%22scy%22%3A%22auto%22%2C%22net%22%3A%22ws%22%2C%22type%22%3A%22none%22%2C%22host%22%3A%22cdn.example.com%22%2C%22path%22%3A%22%2Fvless%22%2C%22tls%22%3A%22tls%22%7D</a></li><li>V2box deep link: <a href="v2box://import?config=%7B%22v%22%3A%222%22%2C%22ps%22%3A%22Example%20VLESS%22%2C%22add%22%3A%22example.com%22%2C%22port%22%3A443%2C%22id%22%3A%22d3d94468-2e02-4a02-b1f5-8da3eb3b0123%22%2C%22aid%22%3A0%2C%22scy%22%3A%22auto%22%2C%22net%22%3A%22ws%22%2C%22type%22%3A%22none%22%2C%22host%22%3A%22cdn.example.com%22%2C%22path%22%3A%22%2Fvless%22%2C%22tls%22%3A%22tls%22%7D">v2box://import?config=%7B%22v%22%3A%222%22%2C%22ps%22%3A%22Example%20VLESS%22%2C%22add%22%3A%22example.com%22%2C%22port%22%3A443%2C%22id%22%3A%22d3d94468-2e02-4a02-b1f5-8da3eb3b0123%22%2C%22aid%22%3A0%2C%22scy%22%3A%22auto%22%2C%22net%22%3A%22ws%22%2C%22type%22%3A%22none%22%2C%22host%22%3A%22cdn.example.com%22%2C%22path%22%3A%22%2Fvless%22%2C%22tls%22%3A%22tls%22%7D</a></li></ol>
@@ -25,5 +25,34 @@
 <footer>
   <p><a href="index.html">Back to all stories</a></p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "how-this-blog-works.html",
+        "researching-el-norte-de-espana.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/researching-el-norte-de-espana.html
+++ b/docs/researching-el-norte-de-espana.html
@@ -4,7 +4,7 @@
 <title>Researching El Norte de España – Wanderlust &amp; Wonder</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="style.css">
-<body>
+<body class="post">
 <header>
   <p><a href="index.html">Wanderlust &amp; Wonder</a></p>
   <p>Tiny stories from the road</p>
@@ -12,12 +12,12 @@
 <main>
   <article>
     <h1>Researching El Norte de España</h1>
-    <p class="post-date">January 25, 2024</p>
+    <p class="post-date"><time datetime="2024-01-25">January 25, 2024</time></p>
     <p>There&#x27;s something about northern Spain that calls to me. Maybe it&#x27;s the rugged coastline, the ancient Celtic heritage, or the way the mountains meet the sea. I&#x27;ve been researching the region for months now, and each discovery makes me more eager to visit.</p>
 <p>The Camino de Santiago has been on my bucket list forever, but I&#x27;m particularly drawn to the northern route - the Camino del Norte. It follows the coast from Irún to Santiago, passing through the Basque Country, Cantabria, Asturias, and Galicia. The scenery must be incredible.</p>
 <p>What fascinates me most is the cultural diversity. The Basque language, Euskera, is completely unrelated to any other European language. The Asturian bagpipes, the Celtic influence in Galicia - it&#x27;s like stepping into a different world within Spain itself.</p>
-<p>I&#x27;ve been reading about the fishing villages along the coast, places like San Sebastián and Santander. The food culture is incredible - fresh seafood, cider from Asturias, the famous pintxos in the Basque Country. Each region has its own culinary traditions.</p>
-<p>The architecture is another draw. From the Gothic cathedrals to the traditional caseríos (farmhouses) in the countryside, there&#x27;s such a rich variety. The Guggenheim in Bilbao is obviously famous, but I&#x27;m more interested in the smaller museums and cultural centers.</p>
+<p>I&#x27;ve been reading about the fishing villages along the coast, places like San Sebastián and Santander. The food culture is incredible - fresh seafood, cider from Asturias, the famous <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-1">pintxos</button><aside id="glossary-popover-1" class="glossary-popover" popover="auto" role="note"><strong>pintxos</strong><span class="glossary-definition">Small bites served on bread, often skewered, that anchor the Basque bar-hopping ritual.</span></aside></span> in the Basque Country. Each region has its own culinary traditions.</p>
+<p>The architecture is another draw. From the Gothic cathedrals to the traditional <span class="glossary-term"><button type="button" class="glossary-trigger" popovertarget="glossary-popover-2">caseríos</button><aside id="glossary-popover-2" class="glossary-popover" popover="auto" role="note"><strong>caseríos</strong><span class="glossary-definition">Whitewashed Basque farmhouses built for multi-generational families.</span></aside></span> in the countryside, there&#x27;s such a rich variety. The Guggenheim in Bilbao is obviously famous, but I&#x27;m more interested in the smaller museums and cultural centers.</p>
 <p>Planning to spend at least a month there next spring. Want to walk parts of the Camino, explore the coastal towns, and really immerse myself in the local culture. Sometimes the best trips are the ones you research obsessively before going.</p>
 <p>El norte de España, te espero.</p>
   </article>
@@ -25,5 +25,34 @@
 <footer>
   <p><a href="index.html">Back to all stories</a></p>
 </footer>
+<script type="speculationrules">
+{
+  "prefetch": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ]
+    }
+  ],
+  "prerender": [
+    {
+      "source": "list",
+      "urls": [
+        "index.html",
+        "ios-deep-links-for-vless.html",
+        "how-this-blog-works.html",
+        "interesting-meeting-in-cement-museum.html",
+        "great-weekend-in-almaty.html"
+      ],
+      "eagerness": "moderate"
+    }
+  ]
+}
+</script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,47 +1,60 @@
-/* Tiny, readable defaults */
+/* Tiny, readable defaults with modern touches */
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.6;
   margin: 0;
-  --hn-bg: #ffffff;
-  --hn-surface: #f4f4f5;
-  --hn-text: #1e1e1e;
-  --hn-muted: #6b7280;
-  --hn-accent: #ff6600;
-  --hn-accent-hover: #cc5200;
+  --surface: color-mix(in srgb, Canvas 92%, CanvasText 8%);
+  --surface-border: color-mix(in srgb, CanvasText 20%, transparent);
+  --card-radius: 1.1rem;
 }
 body {
-  background-color: var(--hn-bg);
-  color: var(--hn-text);
+  background: color-mix(in srgb, Canvas 98%, CanvasText 3%);
   margin: 0 auto;
-  max-width: 48rem;
+  max-width: 52rem;
   padding: 2.5rem 1.5rem 4rem;
 }
 a {
-  color: var(--hn-accent);
-}
-
-a:hover,
-a:focus {
-  color: var(--hn-accent-hover);
+  color: inherit;
 }
 header,
 footer {
   text-align: center;
   margin-bottom: 2.5rem;
 }
-nav a {
-  text-decoration: none;
-  font-weight: 600;
+main.feed {
+  display: grid;
+  gap: 2rem;
 }
-article {
-  margin-bottom: 3rem;
+.post-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--card-radius);
+  box-shadow: 0 1rem 2rem -1.5rem color-mix(in srgb, CanvasText 40%, transparent);
+  padding: 1.75rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+.post-card:hover,
+.post-card:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 1.35rem 2.75rem -1.5rem color-mix(in srgb, CanvasText 45%, transparent);
+}
+.post-card h2 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.4rem, 1.2rem + 0.5vw, 1.7rem);
+}
+.post-card > .post-date {
+  color: color-mix(in srgb, CanvasText 55%, transparent);
+  font-size: 0.9rem;
+  margin: 0;
+}
+.post-card > p {
+  margin-top: 0.9rem;
 }
 .post-date {
-  color: var(--hn-muted);
+  color: color-mix(in srgb, CanvasText 55%, transparent);
   font-size: 0.9rem;
-  margin-top: -0.5rem;
+  margin-top: -0.25rem;
 }
 ul {
   padding-left: 1.2rem;
@@ -49,7 +62,54 @@ ul {
 pre,
 code {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  background-color: var(--hn-surface);
-  border-radius: 4px;
-  padding: 0.25rem 0.4rem;
+}
+.glossary-term {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+.glossary-trigger {
+  background: none;
+  border: 0;
+  border-bottom: 1px dashed currentColor;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+.glossary-trigger:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 3px;
+}
+.glossary-popover {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 1.75rem 3rem -2rem color-mix(in srgb, CanvasText 40%, transparent);
+  margin: 0;
+  max-width: min(24rem, 80vw);
+  padding: 1rem 1.25rem;
+}
+.glossary-popover:popover-open {
+  animation: popover-in 120ms ease;
+}
+.glossary-popover strong {
+  display: block;
+  font-size: 0.95rem;
+  margin-bottom: 0.4rem;
+}
+.glossary-definition {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+@keyframes popover-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/posts/2024-01-25-researching-el-norte-de-espana.txt
+++ b/posts/2024-01-25-researching-el-norte-de-espana.txt
@@ -6,9 +6,9 @@ The Camino de Santiago has been on my bucket list forever, but I'm particularly 
 
 What fascinates me most is the cultural diversity. The Basque language, Euskera, is completely unrelated to any other European language. The Asturian bagpipes, the Celtic influence in Galicia - it's like stepping into a different world within Spain itself.
 
-I've been reading about the fishing villages along the coast, places like San Sebastián and Santander. The food culture is incredible - fresh seafood, cider from Asturias, the famous pintxos in the Basque Country. Each region has its own culinary traditions.
+I've been reading about the fishing villages along the coast, places like San Sebastián and Santander. The food culture is incredible - fresh seafood, cider from Asturias, the famous ((pintxos::Small bites served on bread, often skewered, that anchor the Basque bar-hopping ritual.)) in the Basque Country. Each region has its own culinary traditions.
 
-The architecture is another draw. From the Gothic cathedrals to the traditional caseríos (farmhouses) in the countryside, there's such a rich variety. The Guggenheim in Bilbao is obviously famous, but I'm more interested in the smaller museums and cultural centers.
+The architecture is another draw. From the Gothic cathedrals to the traditional ((caseríos::Whitewashed Basque farmhouses built for multi-generational families.)) in the countryside, there's such a rich variety. The Guggenheim in Bilbao is obviously famous, but I'm more interested in the smaller museums and cultural centers.
 
 Planning to spend at least a month there next spring. Want to walk parts of the Camino, explore the coastal towns, and really immerse myself in the local culture. Sometimes the best trips are the ones you research obsessively before going.
 

--- a/posts/2024-01-30-how-this-blog-works.txt
+++ b/posts/2024-01-30-how-this-blog-works.txt
@@ -1,8 +1,8 @@
 How This Blog Works
 
-This site is deliberately tiny. Every story lives as a text file inside the `posts/` folder, and `python3 build.py` glues them together into one HTML page at `docs/index.html`.
+This site is deliberately tiny—a ((static site::A collection of pages that are prebuilt ahead of time and can be served as-is from any web host.)) Every story lives as a text file inside the `posts/` folder, and `python3 build.py` glues them together into one HTML page at `docs/index.html`.
 
-To add something new, drop another text file in `posts/` using the pattern `YYYY-MM-DD-short-title.txt`. Keep the title on the first line, leave a blank line, and then write the story in plain paragraphs or bullets that start with `- `. Run `python3 build.py` to rebuild the page.
+To add something new, drop another text file in `posts/` using the pattern `YYYY-MM-DD-short-title.txt`. Keep the title on the first line, leave a blank line, and then write the story in plain paragraphs or bullets that start with `- `. Run `python3 build.py` to rebuild the page with a fresh ((build step::A single command that regenerates every page from the source files so nothing can fall out of sync.)).
 
 Need to remove a story? Delete its text file and rebuild. The single page is recreated from scratch each time, so it will only show the files that still exist.
 


### PR DESCRIPTION
## Summary
- extend the static site builder with glossary popovers, declarative shadow DOM cards, and speculation rules support while refreshing the shared stylesheet
- update existing posts to use inline glossary annotations that render through the Popover API
- regenerate the published HTML to ship encapsulated post cards and instant-navigation speculation scripts

## Testing
- python3 build.py

------
https://chatgpt.com/codex/tasks/task_e_68f01cbafd68832e909738963ad79d82