### PR TITLE
Add Apple Notes capture workflow for new posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@ A premium static travel blog powered by one Python script and Tailwind CSS via C
 
 1. Write posts inside `posts/` using the filename pattern `YYYY-MM-DD-slug.txt` (Markdown is also accepted).
 2. Put the title on the first non-empty line; the rest of the file becomes the body.
-3. Run:
+3. To turn an Apple Note into a post, copy the note and run:
+   ```bash
+   python3 build.py capture
+   ```
+   The script reads from the macOS clipboard, cleans up bullet points and metadata, creates a correctly named file inside `posts/`,
+   and rebuilds the site. You can also pipe note text manually with `--stdin` or pick a publication date via `--date YYYY-MM-DD`.
+4. To regenerate the site without capturing a note, run:
    ```bash
    python3 build.py
    ```
-4. Open `docs/index.html` locally or push the repo — GitHub Pages can publish the `docs/` directory as-is.
+5. Open `docs/index.html` locally or push the repo — GitHub Pages can publish the `docs/` directory as-is.
 
 Removing a post is as simple as deleting its file and running `build.py` again. The builder also cleans up stale HTML in `docs/`.
 

--- a/build.py
+++ b/build.py
@@ -3,14 +3,17 @@
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
+import subprocess
 import html
 import re
 from string import Template
 from textwrap import shorten
 from typing import Iterable
+import sys
 
 POSTS_DIR = Path("posts")
 OUTPUT_DIR = Path("docs")
@@ -227,6 +230,172 @@ def slugify(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower())
     slug = slug.strip("-")
     return slug or "section"
+
+
+def normalize_whitespace(text: str) -> str:
+    return "\n".join(line.rstrip() for line in text.replace("\r\n", "\n").splitlines())
+
+
+METADATA_PATTERNS = [
+    re.compile(
+        r"^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+"
+        r"[A-Za-z]+\s+\d{1,2},\s+\d{4}(\s+at\s+\d{1,2}:\d{2}\s+[AP]M)?$"
+    ),
+    re.compile(r"^[A-Za-z]+\s+\d{1,2},\s+\d{4}(\s+at\s+\d{1,2}:\d{2}\s+[AP]M)?$"),
+    re.compile(r"^\d{1,2}:\d{2}\s+[AP]M$"),
+    re.compile(r"^(Created|Updated)\s+.+$"),
+]
+
+
+def looks_like_metadata(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    for pattern in METADATA_PATTERNS:
+        if pattern.match(stripped):
+            return True
+    return False
+
+
+def transform_bullet(line: str) -> str:
+    stripped = line.lstrip()
+    prefix = line[: len(line) - len(stripped)]
+    bullet_replacements = {
+        "•": "-",
+        "◦": "  -",
+        "▪": "-",
+        "‣": "-",
+        "–": "-",
+        "—": "-",
+        "○": "- [ ]",
+        "●": "- [x]",
+    }
+    for symbol, replacement in bullet_replacements.items():
+        if stripped.startswith(symbol + " "):
+            return prefix + replacement + stripped[len(symbol) :]
+        if stripped.startswith(symbol + "\t"):
+            return prefix + replacement + " " + stripped[len(symbol) + 1 :]
+        if stripped == symbol:
+            return prefix + replacement
+    return line
+
+
+def convert_apple_note(text: str) -> tuple[str, str]:
+    normalized = normalize_whitespace(text)
+    lines = [line.replace("\u00a0", " ") for line in normalized.split("\n")]
+
+    title = ""
+    body_lines: list[str] = []
+    for line in lines:
+        if not title and line.strip():
+            title = line.strip()
+            continue
+        if title:
+            body_lines.append(line)
+
+    if not title:
+        title = "Untitled Note"
+
+    while body_lines and not body_lines[0].strip():
+        body_lines.pop(0)
+
+    while True:
+        removed = False
+        if body_lines and looks_like_metadata(body_lines[0]):
+            body_lines.pop(0)
+            removed = True
+        elif (
+            len(body_lines) >= 2
+            and body_lines[0].strip()
+            and "," in body_lines[0]
+            and looks_like_metadata(body_lines[1])
+        ):
+            body_lines.pop(0)
+            removed = True
+
+        if removed:
+            while body_lines and not body_lines[0].strip():
+                body_lines.pop(0)
+        else:
+            break
+
+    converted_lines: list[str] = []
+    for line in body_lines:
+        if not line.strip():
+            if converted_lines and converted_lines[-1]:
+                converted_lines.append("")
+            continue
+        converted_lines.append(transform_bullet(line.rstrip()))
+
+    body = "\n".join(converted_lines).strip()
+    return title, body
+
+
+def read_clipboard_text(use_stdin: bool = False) -> str:
+    if use_stdin:
+        return sys.stdin.read()
+
+    if sys.platform == "darwin":
+        try:
+            completed = subprocess.run(
+                ["pbpaste"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return completed.stdout
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            pass
+
+    raise RuntimeError(
+        "Clipboard capture failed. Re-run with --stdin and paste the note content manually."
+    )
+
+
+def ensure_posts_dir() -> None:
+    POSTS_DIR.mkdir(exist_ok=True)
+
+
+def next_post_path(post_date: date, slug: str) -> Path:
+    date_str = post_date.strftime("%Y-%m-%d")
+    base = POSTS_DIR / f"{date_str}-{slug}.txt"
+    if not base.exists():
+        return base
+
+    counter = 2
+    while True:
+        candidate = POSTS_DIR / f"{date_str}-{slug}-{counter}.txt"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def capture_post_from_clipboard(
+    *,
+    post_date: date | None = None,
+    desired_slug: str | None = None,
+    use_stdin: bool = False,
+) -> Path:
+    raw = read_clipboard_text(use_stdin=use_stdin)
+    if not raw.strip():
+        raise RuntimeError("Clipboard is empty. Copy a note first or use --stdin.")
+
+    title, body = convert_apple_note(raw)
+    if not body:
+        body = ""
+
+    slug = slugify(desired_slug or title)
+    post_date = post_date or date.today()
+
+    ensure_posts_dir()
+    target_path = next_post_path(post_date, slug)
+    content_lines = [title.strip()]
+    if body:
+        content_lines.append("")
+        content_lines.append(body.strip())
+    content = "\n".join(content_lines).strip() + "\n"
+    target_path.write_text(content, encoding="utf-8")
+    return target_path
 
 
 def render_body(body: str) -> RenderedBody:
@@ -653,5 +822,66 @@ def build() -> None:
     )
 
 
-if __name__ == "__main__":
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Static blog helper utilities")
+    subparsers = parser.add_subparsers(dest="command")
+
+    build_parser = subparsers.add_parser("build", help="Render the site")
+    build_parser.set_defaults(command="build")
+
+    capture_parser = subparsers.add_parser(
+        "capture", help="Convert the current Apple Note into a blog post"
+    )
+    capture_parser.add_argument(
+        "--date",
+        help="Publication date in YYYY-MM-DD format (defaults to today)",
+    )
+    capture_parser.add_argument(
+        "--slug",
+        help="Custom slug to use for the post filename",
+    )
+    capture_parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read note content from standard input instead of the clipboard",
+    )
+
+    parser.set_defaults(command="build")
+    return parser.parse_args(argv)
+
+
+def handle_capture(args: argparse.Namespace) -> None:
+    post_date = None
+    if args.date:
+        try:
+            post_date = datetime.strptime(args.date, "%Y-%m-%d").date()
+        except ValueError as exc:
+            raise SystemExit(f"Invalid date '{args.date}': {exc}") from exc
+
+    try:
+        post_path = capture_post_from_clipboard(
+            post_date=post_date,
+            desired_slug=args.slug,
+            use_stdin=args.stdin,
+        )
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    try:
+        display_path = post_path.relative_to(Path.cwd())
+    except ValueError:
+        display_path = post_path
+    print(f"Created {display_path}")
     build()
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.command == "capture":
+        handle_capture(args)
+    else:
+        build()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `build.py capture` subcommand that reads the macOS clipboard and writes a new post file with Apple Notes cleanup applied
- normalize pasted content by stripping Apple Notes metadata, converting bullets to Markdown, and auto-generating slugs
- document the new workflow in the README and retain the regular build command for manual rebuilds

## Testing
- python3 build.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68fbb04e1a2c832ebf80e8b76a45ccbe)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new CLI/file-writing and subprocess clipboard access (`pbpaste`), which can fail platform-dependently or overwrite/create unexpected post files if parsing/slugging is off; core rendering logic is largely unchanged.
> 
> **Overview**
> Adds a `build.py capture` subcommand that reads Apple Notes content (macOS clipboard via `pbpaste`, or `--stdin`), converts it into a new dated post file under `posts/`, and then triggers a site rebuild.
> 
> The capture pipeline strips common Apple Notes metadata lines, normalizes whitespace, converts various bullet symbols (including checkbox bullets) to Markdown, auto-generates a unique slug/filename (with `--slug` and `--date` overrides), and documents the new workflow in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 860c004cb79f8308f26275eb5df99a5133197624. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->