### PR TITLE
Add standalone SVG aircraft turbine blade 3D viewer page

### DIFF
--- a/docs/aircraft-turbine-blade-viewer.html
+++ b/docs/aircraft-turbine-blade-viewer.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Aircraft Turbine Blade</title>
+  <style>
+    :root { --bg0:#0b0e14; --bg1:#111723; --panel:rgba(18,24,36,.84); --panel-border:rgba(190,210,255,.25); --text:#d8e2f2; --muted:#9aa8c3; --accent:#80d5ff; }
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100vh;font-family:Inter,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:var(--text);background:radial-gradient(circle at 22% 18%,#1a2436 0%,var(--bg1) 28%,var(--bg0) 70%);display:grid;place-items:center;overflow:hidden}
+    .viewer-shell{width:min(95vw,1200px);height:min(92vh,820px);border:1px solid rgba(170,195,245,.2);border-radius:18px;background:linear-gradient(160deg,rgba(255,255,255,.03),rgba(255,255,255,.01));position:relative;box-shadow:0 24px 60px rgba(0,0,0,.5),inset 0 1px 0 rgba(255,255,255,.07);overflow:hidden}
+    svg{width:100%;height:100%;display:block;cursor:grab;touch-action:none} svg.dragging{cursor:grabbing}
+    .hud{position:absolute;top:14px;right:14px;width:min(35vw,355px);padding:12px 14px;border-radius:12px;background:var(--panel);border:1px solid var(--panel-border);backdrop-filter:blur(5px);box-shadow:0 14px 32px rgba(0,0,0,.35);font-size:13px;line-height:1.4;pointer-events:none}
+    .hud h1{margin:0 0 8px;font-size:18px;letter-spacing:.02em;color:#eef6ff}.hud .section{margin-top:8px}.hud p{margin:5px 0;color:var(--muted)}.hud strong{color:var(--accent);font-weight:600}
+    .controls{position:absolute;left:14px;bottom:14px;display:flex;align-items:center;gap:10px;background:rgba(12,18,28,.8);border:1px solid rgba(148,182,255,.27);border-radius:999px;padding:8px 12px;box-shadow:0 10px 25px rgba(0,0,0,.35);font-size:12px;color:var(--muted)}
+    button{border:1px solid rgba(146,184,255,.4);background:rgba(91,133,218,.16);color:#deebff;padding:5px 10px;border-radius:999px;font-size:12px;cursor:pointer}
+    .legend-line{position:absolute;inset:auto 0 58px;text-align:center;font-size:12px;color:#8fa2c8;letter-spacing:.02em;pointer-events:none}
+  </style>
+</head>
+<body>
+  <div class="viewer-shell">
+    <svg id="viewport" viewBox="0 0 1200 820" aria-label="Interactive 3D turbine blade viewer"><g id="mesh"></g></svg>
+    <aside class="hud">
+      <h1>Aircraft Turbine Blade</h1>
+      <div class="section">
+        <p>• A swept, twisted <strong>airfoil blade</strong> that extracts or adds energy to compressible flow.</p>
+        <p>• Root geometry is wider and thicker to carry load into the disk and hub.</p>
+        <p>• Tip sections are thinner and narrower to reduce drag and secondary losses.</p>
+      </div>
+      <div class="section">
+        <p>• Operates under <strong>extreme temperature</strong>, pressure, and cyclic rotational stress.</p>
+        <p>• Efficiency depends on micron-scale aerodynamic precision across the full span.</p>
+        <p>• Built from advanced superalloys and high-control manufacturing processes.</p>
+      </div>
+    </aside>
+    <div class="controls"><span>Drag to rotate</span><button id="resetBtn" type="button">Reset view</button><button id="wireBtn" type="button">Wireframe: Off</button></div>
+    <div class="legend-line">SVG-only manual 3D pipeline · perspective projection · depth sorting · Lambert shading</div>
+  </div>
+
+  <script>
+  (()=>{
+    const svg=document.getElementById('viewport'),meshLayer=document.getElementById('mesh'),resetBtn=document.getElementById('resetBtn'),wireBtn=document.getElementById('wireBtn');
+    const W=1200,H=820,CX=W*.5,CY=H*.54,CAMERA_Z=780,FOCAL=920;
+    const lightDir=normalize([.55,-.55,1]),ambient=.28,diffuse=.72,baseColor=[142,171,220];
+    const state={rotX:-.55,rotY:.65,velX:0,velY:0,drag:false,lastX:0,lastY:0,lastT:0,wire:false,idle:0};
+    const geometry=buildBladeGeometry(48,28); let faceNodes=[];
+    const clamp=(v,lo,hi)=>Math.max(lo,Math.min(hi,v)),mix=(a,b,t)=>a+(b-a)*t,smoothStep=t=>t*t*(3-2*t);
+    function normalize(v){const m=Math.hypot(v[0],v[1],v[2])||1;return[v[0]/m,v[1]/m,v[2]/m]}
+    const cross=(a,b)=>[a[1]*b[2]-a[2]*b[1],a[2]*b[0]-a[0]*b[2],a[0]*b[1]-a[1]*b[0]],sub=(a,b)=>[a[0]-b[0],a[1]-b[1],a[2]-b[2]];
+    const rotX=(p,a)=>{const c=Math.cos(a),s=Math.sin(a);return[p[0],c*p[1]-s*p[2],s*p[1]+c*p[2]]};
+    const rotY=(p,a)=>{const c=Math.cos(a),s=Math.sin(a);return[c*p[0]+s*p[2],p[1],-s*p[0]+c*p[2]]};
+    const rotate2D=(x,y,a)=>{const c=Math.cos(a),s=Math.sin(a);return[x*c-y*s,x*s+y*c]};
+
+    // Airfoil-like section using a NACA-style thickness term plus camber.
+    function airfoilPoint(t){
+      const x=t,thickness=.14;
+      const yt=5*thickness*(0.2969*Math.sqrt(x)-0.1260*x-0.3516*x*x+0.2843*x*x*x-0.1015*x*x*x*x);
+      const yc=.035*Math.sin(Math.PI*x);
+      return{x:x-.42,yTop:yc+yt,yBot:yc-yt};
+    }
+
+    function bladeSection(s,count){
+      const points=[];
+      for(let i=0;i<count;i++){const t=i/(count-1),p=airfoilPoint(t);points.push([p.x,p.yTop])}
+      for(let i=count-2;i>0;i--){const t=i/(count-1),p=airfoilPoint(t);points.push([p.x,p.yBot])}
+      const ss=smoothStep(s),chord=mix(210,112,ss),thickScale=mix(1.2,.62,ss),twist=mix(-.16,1.08,ss),bow=22*Math.sin(Math.PI*s)-7*s*s,lean=mix(-14,26,ss),zPos=mix(-245,245,s);
+      return points.map(([x,y])=>{const px=x*chord,py=y*chord*thickScale,[rx,ry]=rotate2D(px,py,twist);return[rx+bow,ry+lean,zPos]});
+    }
+
+    function buildBladeGeometry(slices,perSide){
+      const rings=[]; for(let s=0;s<=slices;s++) rings.push(bladeSection(s/slices,perSide));
+      const verts=rings.flat(),ringCount=rings[0].length,idx=(si,pi)=>si*ringCount+pi,faces=[];
+      for(let s=0;s<slices;s++) for(let p=0;p<ringCount;p++){const p2=(p+1)%ringCount,a=idx(s,p),b=idx(s+1,p),c=idx(s+1,p2),d=idx(s,p2); faces.push([a,b,c],[a,c,d]);}
+      const rootCenter=verts.length,tipCenter=verts.length+1; verts.push([0,0,rings[0][0][2]],[0,0,rings[rings.length-1][0][2]]);
+      for(let p=0;p<ringCount;p++){const p2=(p+1)%ringCount; faces.push([rootCenter,idx(0,p2),idx(0,p)]); faces.push([tipCenter,idx(slices,p),idx(slices,p2)]);}
+      return{verts,faces};
+    }
+
+    const project=p=>{const z=p[2]+CAMERA_Z,inv=FOCAL/Math.max(120,z);return[CX+p[0]*inv,CY-p[1]*inv,z]};
+    function initFaceNodes(){const frag=document.createDocumentFragment();faceNodes=geometry.faces.map(()=>{const poly=document.createElementNS('http://www.w3.org/2000/svg','polygon');poly.setAttribute('stroke-linejoin','round');frag.appendChild(poly);return poly});meshLayer.appendChild(frag)}
+
+    function render(){
+      const transformed=geometry.verts.map(p=>rotY(rotX(p,state.rotX),state.rotY)),projected=transformed.map(project);
+      const records=geometry.faces.map((f,i)=>{const a=transformed[f[0]],b=transformed[f[1]],c=transformed[f[2]],n=normalize(cross(sub(b,a),sub(c,a)));const intensity=clamp(ambient+diffuse*Math.max(0,n[0]*lightDir[0]+n[1]*lightDir[1]+n[2]*lightDir[2]),0,1);const shade=[Math.round(baseColor[0]*intensity),Math.round(baseColor[1]*intensity),Math.round(baseColor[2]*intensity)];return{i,depth:(projected[f[0]][2]+projected[f[1]][2]+projected[f[2]][2])/3,points:`${projected[f[0]][0].toFixed(2)},${projected[f[0]][1].toFixed(2)} ${projected[f[1]][0].toFixed(2)},${projected[f[1]][1].toFixed(2)} ${projected[f[2]][0].toFixed(2)},${projected[f[2]][1].toFixed(2)}`,fill:`rgb(${shade[0]}, ${shade[1]}, ${shade[2]})`};});
+      records.sort((A,B)=>B.depth-A.depth);
+      for(let order=0;order<records.length;order++){const rec=records[order],node=faceNodes[rec.i];meshLayer.appendChild(node);node.setAttribute('points',rec.points);node.setAttribute('fill',rec.fill);if(state.wire){node.setAttribute('stroke','rgba(220,232,255,.43)');node.setAttribute('stroke-width','.65')}else{node.setAttribute('stroke','rgba(18,24,36,.12)');node.setAttribute('stroke-width','.35')}}
+    }
+
+    function pointerDown(e){state.drag=true;state.lastX=e.clientX;state.lastY=e.clientY;state.lastT=performance.now();state.idle=0;svg.classList.add('dragging')}
+    function pointerMove(e){if(!state.drag) return;const now=performance.now(),dx=e.clientX-state.lastX,dy=e.clientY-state.lastY,dt=Math.max(8,now-state.lastT),k=.0066;state.rotY+=dx*k;state.rotX=clamp(state.rotX+dy*k,-1.55,1.55);state.velY=dx/dt*.09;state.velX=dy/dt*.09;state.lastX=e.clientX;state.lastY=e.clientY;state.lastT=now;}
+    function pointerUp(){state.drag=false;svg.classList.remove('dragging')}
+
+    function animate(){
+      if(!state.drag){state.rotY+=state.velY;state.rotX=clamp(state.rotX+state.velX,-1.55,1.55);state.velX*=.94;state.velY*=.94;const moving=Math.abs(state.velX)+Math.abs(state.velY);if(moving<.00025){state.idle+=1;if(state.idle>110) state.rotY+=.0022;} else state.idle=0;}
+      render(); requestAnimationFrame(animate);
+    }
+
+    resetBtn.addEventListener('click',()=>{state.rotX=-.55;state.rotY=.65;state.velX=0;state.velY=0;state.idle=0});
+    wireBtn.addEventListener('click',()=>{state.wire=!state.wire;wireBtn.textContent=`Wireframe: ${state.wire?'On':'Off'}`});
+    svg.addEventListener('pointerdown',e=>{svg.setPointerCapture(e.pointerId);pointerDown(e)});
+    svg.addEventListener('pointermove',pointerMove);svg.addEventListener('pointerup',pointerUp);svg.addEventListener('pointercancel',pointerUp);svg.addEventListener('lostpointercapture',pointerUp);
+    initFaceNodes(); animate();
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a single-file, production-quality frontend demo that demonstrates a manual SVG-based 3D rendering pipeline for an aircraft turbine blade. 
- Ship a self-contained page that can be opened locally with no external libraries or assets and that reads as a physically plausible turbine/compressor blade. 

### Description
- Add `docs/aircraft-turbine-blade-viewer.html`, a single self-contained HTML file that procedurally generates a blade (airfoil-like cross-sections swept along the span with taper, twist, chord/thickness variation, and root/tip caps). 
- Implement an explicit 3D pipeline in vanilla JS: 3D vertex generation, rotation (`rotX`/`rotY`), perspective projection, face normal calculation, painter’s-depth sorting, and rendering to SVG `<polygon>` elements with simple Lambert shading. 
- Add interaction and UX features: pointer-drag rotation (horizontal -> Y, vertical -> X), inertial continuation, idle auto-rotate, `Reset view` and `Wireframe` toggle controls, and a compact technical HUD describing the blade and its engineering constraints. 

### Testing
- Ran `python3 build.py` which completed successfully and printed a generation summary (`Generated 6 post page(s) plus index.html, about.html, and archive.html`). 
- Verified repository state and created a commit with `git add` / `git commit` which succeeded and added `docs/aircraft-turbine-blade-viewer.html` to the tree. 
- Confirmed the new page is self-contained (no external assets or CDN references) and present at `docs/aircraft-turbine-blade-viewer.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e47c8f9ad0832ebebbe59f01234836)