### PR TITLE
Avoid per-frame SVG reparenting to fix iPhone rendering

### DIFF
--- a/docs/aircraft-turbine-blade-viewer.html
+++ b/docs/aircraft-turbine-blade-viewer.html
@@ -113,7 +113,7 @@
       for(let order=0;order<faceNodes.length;order++){
         const node=faceNodes[order],rec=records[order];
         if(!rec){node.setAttribute('points','');node.setAttribute('fill','none');node.setAttribute('stroke','none');continue;}
-        meshLayer.appendChild(node);node.setAttribute('points',rec.points);node.setAttribute('fill',rec.fill);
+        node.setAttribute('points',rec.points);node.setAttribute('fill',rec.fill);
         if(state.wire){node.setAttribute('stroke','rgba(220,232,255,.43)');node.setAttribute('stroke-width','.65')}else{node.setAttribute('stroke','rgba(18,24,36,.12)');node.setAttribute('stroke-width','.35')}
       }
     }


### PR DESCRIPTION
### Motivation
- Reduce SVG DOM churn on mobile so the turbine blade becomes visible and responsive in iPhone Safari/Chrome by eliminating unnecessary per-frame node reparenting.

### Description
- Removed the single per-frame `meshLayer.appendChild(node)` call from the render loop and kept the existing painter-order mapping of sorted `records[order]` onto pre-created `faceNodes[order]`, while preserving projection math, finite-coordinate guards, HUD, controls, and pointer/touch rotation.

### Testing
- Applied the patch via a small script, inspected the change with `git diff` (single-line change), verified repository status with `git status --short`, and committed with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49c522cb4832ea4dea59f7599e0b6)