### PR TITLE
Fix TDZ error for smoothStep in turbine blade viewer

### DIFF
--- a/docs/aircraft-turbine-blade-viewer.html
+++ b/docs/aircraft-turbine-blade-viewer.html
@@ -64,9 +64,9 @@
     const state={rotX:-0.36,rotY:0.92,velX:0,velY:0,drag:false,lastX:0,lastY:0,lastT:0,wire:false,idle:0};
     let needsRender=true;
 
-    const clamp=(v,lo,hi)=>Math.max(lo,Math.min(hi,v));
-    const mix=(a,b,t)=>a+(b-a)*t;
-    const smoothStep=t=>t*t*(3-2*t);
+    function clamp(v,lo,hi){return Math.max(lo,Math.min(hi,v));}
+    function mix(a,b,t){return a+(b-a)*t;}
+    function smoothStep(t){return t*t*(3-2*t);}
 
     function normalize(v){
       const m=Math.hypot(v[0],v[1],v[2])||1;


### PR DESCRIPTION
### Motivation
- Top-level geometry construction called `bladeSection(...)` which used `smoothStep` while it was declared as a `const` arrow function, causing a temporal dead zone error (`Cannot access 'smoothStep' before initialization`).

### Description
- Replace the `const` arrow utilities `clamp`, `mix`, and `smoothStep` with hoisted function declarations in `docs/aircraft-turbine-blade-viewer.html` so they are callable during script initialization.

### Testing
- Ran repository checks (`git -C /workspace/blog diff --check HEAD~1 HEAD` and `git -C /workspace/blog status --short`) and committed the change with `git -C /workspace/blog commit`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d6092b8c832ea5e3655d04f8ddad)