### PR TITLE
Fix viewer module loading in Chrome and Safari

### DIFF
--- a/docs/aircraft-turbine-blade-viewer.html
+++ b/docs/aircraft-turbine-blade-viewer.html
@@ -22,6 +22,13 @@
     }
     .toolbar label { font-size: 13px; }
   </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js"
+      }
+    }
+  </script>
 </head>
 <body>
   <div id="app">


### PR DESCRIPTION
## What changed
Adds an import map for the `three` bare module specifier used by Three.js addons such as `OrbitControls.js`.

## Root cause
The viewer imports `OrbitControls` directly from jsDelivr. That module imports `three` using a bare specifier. Without an import map, the browser cannot resolve the module graph, so `main.js` fails before the first render. This makes both the turbine and solar-system scenes appear missing.

## Impact
Restores module resolution for the shared viewer in modern Chrome and Safari.

## Follow-up
PR #29 also replaced the previous detailed turbine implementation with a much simpler BoxGeometry-based model. That visual regression is separate from this module-loading failure and should be restored independently.