### PR TITLE
Remove OrbitControls dependency from viewer

### DIFF
--- a/docs/js/viewer/README.tmp
+++ b/docs/js/viewer/README.tmp
@@ -1,0 +1,1 @@
+temporary

--- a/docs/js/viewer/README.tmp
+++ b/docs/js/viewer/README.tmp
@@ -1,1 +1,0 @@
-temporary

--- a/docs/js/viewer/main.js
+++ b/docs/js/viewer/main.js
@@ -1,5 +1,4 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js';
-import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/controls/OrbitControls.js';
 import { SceneManager } from './SceneManager.js';
 import { createTurbineScene } from './scenes/turbineScene.js';
 import { createSolarSystemScene } from './scenes/solarSystemScene.js';
@@ -10,7 +9,7 @@ const speedSlider = document.getElementById('speed');
 const speedValue = document.getElementById('speedValue');
 
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.outputColorSpace = THREE.SRGBColorSpace;
 
@@ -18,11 +17,83 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x090f1d);
 
 const camera = new THREE.PerspectiveCamera(48, window.innerWidth / window.innerHeight, 0.1, 300);
-camera.position.set(8, 5, 10);
+const target = new THREE.Vector3(0, 1.6, 0);
+let radius = 13.5;
+let theta = 0.68;
+let phi = 1.08;
 
-const controls = new OrbitControls(camera, renderer.domElement);
-controls.enableDamping = true;
-controls.target.set(0, 1.6, 0);
+function updateCamera() {
+  const sinPhi = Math.sin(phi);
+  camera.position.set(
+    target.x + radius * sinPhi * Math.sin(theta),
+    target.y + radius * Math.cos(phi),
+    target.z + radius * sinPhi * Math.cos(theta),
+  );
+  camera.lookAt(target);
+}
+updateCamera();
+
+let dragging = false;
+let lastX = 0;
+let lastY = 0;
+
+canvas.style.touchAction = 'none';
+canvas.addEventListener('pointerdown', (event) => {
+  dragging = true;
+  lastX = event.clientX;
+  lastY = event.clientY;
+  canvas.setPointerCapture?.(event.pointerId);
+});
+
+canvas.addEventListener('pointermove', (event) => {
+  if (!dragging) return;
+  const dx = event.clientX - lastX;
+  const dy = event.clientY - lastY;
+  lastX = event.clientX;
+  lastY = event.clientY;
+
+  theta -= dx * 0.008;
+  phi = THREE.MathUtils.clamp(phi + dy * 0.008, 0.2, Math.PI - 0.2);
+  updateCamera();
+});
+
+function stopDragging(event) {
+  dragging = false;
+  canvas.releasePointerCapture?.(event.pointerId);
+}
+canvas.addEventListener('pointerup', stopDragging);
+canvas.addEventListener('pointercancel', stopDragging);
+
+canvas.addEventListener('wheel', (event) => {
+  event.preventDefault();
+  radius = THREE.MathUtils.clamp(radius * Math.exp(event.deltaY * 0.001), 3.5, 40);
+  updateCamera();
+}, { passive: false });
+
+let pinchDistance = null;
+const activeTouches = new Map();
+canvas.addEventListener('pointerdown', (event) => {
+  if (event.pointerType === 'touch') activeTouches.set(event.pointerId, { x: event.clientX, y: event.clientY });
+});
+canvas.addEventListener('pointermove', (event) => {
+  if (event.pointerType !== 'touch' || !activeTouches.has(event.pointerId)) return;
+  activeTouches.set(event.pointerId, { x: event.clientX, y: event.clientY });
+  if (activeTouches.size === 2) {
+    const [a, b] = [...activeTouches.values()];
+    const distance = Math.hypot(a.x - b.x, a.y - b.y);
+    if (pinchDistance !== null && distance > 0) {
+      radius = THREE.MathUtils.clamp(radius * (pinchDistance / distance), 3.5, 40);
+      updateCamera();
+    }
+    pinchDistance = distance;
+  }
+});
+function clearTouch(event) {
+  activeTouches.delete(event.pointerId);
+  if (activeTouches.size < 2) pinchDistance = null;
+}
+canvas.addEventListener('pointerup', clearTouch);
+canvas.addEventListener('pointercancel', clearTouch);
 
 const manager = new SceneManager(scene);
 manager.setScene(createTurbineScene);
@@ -38,8 +109,18 @@ function onResize() {
 window.addEventListener('resize', onResize);
 
 modelPicker.addEventListener('change', () => {
-  if (modelPicker.value === 'solar') manager.setScene(createSolarSystemScene);
-  else manager.setScene(createTurbineScene);
+  if (modelPicker.value === 'solar') {
+    target.set(0, 0, 0);
+    radius = 16;
+    phi = 1.1;
+    manager.setScene(createSolarSystemScene);
+  } else {
+    target.set(0, 1.6, 0);
+    radius = 13.5;
+    phi = 1.08;
+    manager.setScene(createTurbineScene);
+  }
+  updateCamera();
 });
 
 speedSlider.addEventListener('input', () => {
@@ -49,8 +130,7 @@ speedSlider.addEventListener('input', () => {
 
 function animate() {
   requestAnimationFrame(animate);
-  const delta = clock.getDelta();
-  controls.update();
+  const delta = Math.min(clock.getDelta(), 0.1);
   manager.update(delta, speedMultiplier);
   renderer.render(scene, camera);
 }


### PR DESCRIPTION
## What changed
Removes the external `OrbitControls` addon import and replaces it with local pointer, wheel, and pinch camera controls.

## Why
The viewer currently fails as one module graph: if the Three.js addon import cannot resolve or execute in Safari/Chrome/iOS, neither the turbine scene nor the solar-system scene reaches first render. The previous import-map-only fix still left that brittle dependency in place.

## Validation
`main.js` passes `node --check` after the change.

## Scope
This only addresses viewer startup/runtime robustness. Restoring the old detailed turbine geometry remains a separate visual-quality task.